### PR TITLE
Keep going to next digit on button A independent of on/off state

### DIFF
--- a/src/lvgl_porting.cpp
+++ b/src/lvgl_porting.cpp
@@ -209,7 +209,7 @@ static uint32_t keypad_get_key(void)
         else if (output_flag == 1) {
             if (M5.BtnA.wasClicked()) {
                 beep();
-                return 6;
+                return 1; // next (instead of on / off)
             }
             if (M5.BtnB.wasClicked()) {
                 beep();
@@ -234,7 +234,7 @@ static uint32_t keypad_get_key(void)
                 if (M5.BtnB.isHolding()) {
                     beep();
                     btnB_lock_flag = 1;
-                    return 1;
+                    return 7; // mute (instead of next)
                 }
             }
             else {

--- a/src/ui/generated/events_init.cpp
+++ b/src/ui/generated/events_init.cpp
@@ -758,8 +758,14 @@ void set_output(void)
 		lv_obj_clear_flag(guider_ui.screen_running_img_output_enable, LV_OBJ_FLAG_HIDDEN);	
 		lv_obj_clear_flag(guider_ui.screen_running_img_5, LV_OBJ_FLAG_HIDDEN);
 		lv_obj_add_flag(guider_ui.screen_running_img_1, LV_OBJ_FLAG_HIDDEN);
-		lv_obj_add_flag(guider_ui.screen_running_img_loud, LV_OBJ_FLAG_HIDDEN);
-		lv_obj_add_flag(guider_ui.screen_running_img_mute, LV_OBJ_FLAG_HIDDEN);		
+		if (!voice_flag) {
+			lv_obj_add_flag(guider_ui.screen_running_img_mute, LV_OBJ_FLAG_HIDDEN);
+			lv_obj_clear_flag(guider_ui.screen_running_img_loud, LV_OBJ_FLAG_HIDDEN);
+		}
+		else {
+			lv_obj_add_flag(guider_ui.screen_running_img_loud, LV_OBJ_FLAG_HIDDEN);
+			lv_obj_clear_flag(guider_ui.screen_running_img_mute, LV_OBJ_FLAG_HIDDEN);
+		}
 		pps.setPowerEnable(true);		
 	}
 }


### PR DESCRIPTION
The current implementation moves the _next_ functionality from button A (when PPS is off) to button B (when PPS is on). E.g. when PPS is **on**, a short press onto button B increases the value and a long press onto button B moves the cursor to the next digit.

Now, let's say the voltage is set to 5 volts and the cursor sits on the tenth voltage digit and I want to move the cursor. For that I need to **long** press button B, but if I inadvertently **short** press button B then the **tenth digit is increased**, resulting in **15 volts**! Since the PPS is **on** this could be fatal for the device connected to the PPS.  

Therefore I propose the following changes:
- Button A short press: moves the cursor to the next digit (independent of whether PPS is on or off)
- Button B long press: enable / disable tone (independent of whether PPS is on or off)

Note: when PPS is **on** the _next_ functionality is not visually indicated (this is due to the fact that the images are generated and I don't have the means to modify them.)